### PR TITLE
revert: revert "ci(action): update github/codeql-action action to v2.22.0 (#6)"

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@2cb752a87e96af96708ab57187ab6372ee1973ab # v2.22.0
+        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Reverts sheerlox/import-from-esm#6

the [OSSF ScoreCard worflow is erroring](https://github.com/sheerlox/import-from-esm/actions/runs/6431052174/job/17463302344) because of this PR, probably because the hash it was upgraded to do not impact the `upload-sarif` sub-directory, so its treated as an impostor commit by OSSF.