### PR TITLE
fix(typescript): use default export in declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,4 +38,4 @@ declare const importFrom: {
 	silent(fromDirectory: string, moduleId: string): unknown;
 };
 
-export = importFrom;
+export default importFrom;


### PR DESCRIPTION
## Related issue

- https://github.com/sheerlox/import-from-esm/issues/46