### PR TITLE
feat: support index, main and extensionless JSON modules

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -10,6 +10,8 @@
 	"ignore": ["tests/fixture/**"],
 	"ignoreDependencies": [
 		"@insurgent/export-map-test",
+		"@insurgent/json-index-test",
+		"@insurgent/json-main-test",
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/github",
 		"@semantic-release/npm",

--- a/index.js
+++ b/index.js
@@ -28,14 +28,15 @@ async function tryImport(fileURL) {
 		return;
 	}
 
-	const filePath = fileURLToPath(fileURL);
-	const asJSON = extname(filePath) === '.json';
-
-	debug(`Trying to import '${fileURL.href}'${asJSON ? ' as JSON' : ''}`);
 	try {
+		debug(`Trying to determine file extension for '${fileURL.href}'`);
+		const filePath = fileURLToPath(fileURL);
+		const asJSON = extname(filePath) === '.json';
+
+		debug(`Trying to import '${fileURL.href}'${asJSON ? ' as JSON' : ''}`);
 		return asJSON ? require(filePath) : await import(fileURL);
 	} catch (error) {
-		debug(`Failed to import '${fileURL.href}'${asJSON ? ' as JSON' : ''}: ${String(error)}`);
+		debug(`Failed to determine file extension or import '${fileURL.href}': ${String(error)}`);
 		if (error instanceof SyntaxError) {
 			throw error;
 		}
@@ -94,10 +95,14 @@ async function importFrom(fromDirectory, moduleId) {
 	}
 
 	if (!loadedModule) {
-		const error = new Error(`Cannot find module '${moduleId}'`);
+		const errorString = `Cannot find module '${moduleId}'`;
+		debug(errorString);
+		const error = new Error(errorString);
 		error.code = 'MODULE_NOT_FOUND';
 		throw error;
 	}
+
+	debug(`Successfully loaded module '${moduleId}' from '${fromDirectory}'`);
 
 	return loadedModule.default ?? loadedModule;
 }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ async function tryImport(fileURL) {
 		debug(`Trying to import '${fileURL.href}'${asJSON ? ' as JSON' : ''}`);
 		return asJSON ? require(filePath) : await import(fileURL);
 	} catch (error) {
-		debug(`Failed to determine file extension or import '${fileURL.href}': ${String(error)}`);
+		debug(`Failed to determine file extension or to import '${fileURL.href}': ${String(error)}`);
 		if (error instanceof SyntaxError) {
 			throw error;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
 			"devDependencies": {
 				"@fast-check/ava": "1.1.6",
 				"@insurgent/export-map-test": "1.0.0",
+				"@insurgent/json-index-test": "1.0.0",
+				"@insurgent/json-main-test": "1.0.0",
 				"@insurgentlab/conventional-changelog-preset": "7.0.0",
 				"@semantic-release/changelog": "6.0.3",
 				"@semantic-release/git": "10.0.1",
@@ -405,6 +407,18 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@insurgent/export-map-test/-/export-map-test-1.0.0.tgz",
 			"integrity": "sha512-Z2qBhZg6rVM+lpy47c3KKkL1V4g9aABm0oJiu6YwmcXcav+Y1zJx6UoPj0fViSB6KJYs6GQ8WWJ2tC3vDhb04g==",
+			"dev": true
+		},
+		"node_modules/@insurgent/json-index-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@insurgent/json-index-test/-/json-index-test-1.0.0.tgz",
+			"integrity": "sha512-1Ggy4CyTc/qCdsMo3moP9M06seoTcZRs5PtRyOzQlOvf420D8UxB/5DxzspQXBFQxibgevMnjnHQBrp2DAIorA==",
+			"dev": true
+		},
+		"node_modules/@insurgent/json-main-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@insurgent/json-main-test/-/json-main-test-1.0.0.tgz",
+			"integrity": "sha512-eVFCNR2NtxBFc5BsHuF4Me/CC0rN3J9UR7oCtNYpfC/SakRn03wZY1vezthb4kULb/opZMNEQZpJQrFJaYq2fw==",
 			"dev": true
 		},
 		"node_modules/@insurgentlab/conventional-changelog-preset": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
 	"devDependencies": {
 		"@fast-check/ava": "1.1.6",
 		"@insurgent/export-map-test": "1.0.0",
+		"@insurgent/json-index-test": "1.0.0",
+		"@insurgent/json-main-test": "1.0.0",
 		"@insurgentlab/conventional-changelog-preset": "7.0.0",
 		"@semantic-release/changelog": "6.0.3",
 		"@semantic-release/git": "10.0.1",

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -38,3 +38,6 @@ test('package - extension wildcard export', t => testImportFromPackage(t, import
 
 const testPackageJSON = JSON.parse(readFileSync(fileURLToPath(resolve('@insurgent/export-map-test/package.json', import.meta.url))));
 test('package - JSON file export', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/export-map-test/package.json', testPackageJSON));
+
+test('package - JSON index', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/json-index-test', { ok: true }));
+test('package - JSON main', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/json-main-test', { ok: true }));

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -20,6 +20,7 @@ test('local - ESM module in CJS folder - .mjs extension', t => testImportFromLoc
 test('local - JSON files', async t => {
 	const JSON_DIR = 'tests/fixture/json';
 	const NON_EXISTENT_MODULE_ID = './nonexistent.json';
+	t.deepEqual(await importFrom.silent(JSON_DIR, './valid'), { ok: true });
 	t.deepEqual(await importFrom.silent(JSON_DIR, './valid.json'), { ok: true });
 	t.is(await importFrom.silent(JSON_DIR, './invalid.json'), undefined);
 
@@ -38,6 +39,5 @@ test('package - extension wildcard export', t => testImportFromPackage(t, import
 
 const testPackageJSON = JSON.parse(readFileSync(fileURLToPath(resolve('@insurgent/export-map-test/package.json', import.meta.url))));
 test('package - JSON file export', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/export-map-test/package.json', testPackageJSON));
-
-test('package - JSON index', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/json-index-test', { ok: true }));
-test('package - JSON main', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/json-main-test', { ok: true }));
+test('package - JSON index (no entrypoint)', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/json-index-test', { ok: true }));
+test('package - JSON main export', t => testImportFromPackage(t, importFrom, 'tests/fixture/', '@insurgent/json-main-test', { ok: true }));

--- a/tests/fuzz-regression.test.js
+++ b/tests/fuzz-regression.test.js
@@ -1,9 +1,7 @@
 import { fc, testProp } from '@fast-check/ava';
 import { fuzzImportFromESM } from './helpers/fuzz.helpers.js';
 
-// This is skipped in `fuzz.helper.js`, but leaving it
-// to illustrate fuzzing regression for future use
 testProp(
-	'should not error on ["!cBsSgR<","xo"]', [fc.string(), fc.string()], fuzzImportFromESM,
-	{ seed: 841_782_558, path: '54113', verbose: 1, endOnFailure: true },
+	'should not error on [""," A:"]', [fc.string(), fc.string()], fuzzImportFromESM,
+	{ seed: 642_984_661, path: '122:0:3:1:10:17', verbose: 1, endOnFailure: true },
 );


### PR DESCRIPTION
### Description

Add support for loading NPM packages' `index.json` and `main` entry pointing to a JSON file, as well as loading extensionless JSON modules (e.g. `./package`).

### Related issue

- Fixes #49